### PR TITLE
feat: Language-responsive logo display

### DIFF
--- a/app/HomePage.tsx
+++ b/app/HomePage.tsx
@@ -296,7 +296,7 @@ export default function HomePage() {
               <span className="font-bold">{t("app.title")}</span>
             </div>
             <div className="text-sm text-muted-foreground">
-              &copy; {new Date().getFullYear()} DocSign. {t("home.footer.rights")}
+              &copy; {new Date().getFullYear()} Seuk. {t("home.footer.rights")}
             </div>
           </div>
         </div>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { createClient } from "@/lib/supabase/server"
 import DashboardPage from "./DashboardPage"
 
 export const metadata: Metadata = {
-  title: "DocSign - Dashboard",
+  title: "Seuk - Dashboard",
   description: "Manage your documents and signatures",
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,7 @@ import { LanguageProvider } from "@/contexts/language-context"
 const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
-  title: "DocSign - Online Document Signing",
+  title: "Seuk - Online Document Signing",
   description: "Upload, sign, and share documents online with ease",
     generator: 'v0.dev'
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,8 +3,8 @@ import { Suspense } from "react"
 import LoginPage from "./LoginPage"
 
 export const metadata: Metadata = {
-  title: "DocSign - Login",
-  description: "Log in to your DocSign account",
+  title: "Seuk - Login",
+  description: "Log in to your Seuk account",
 }
 
 export default function Login() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next"
 import HomePage from "./HomePage"
 
 export const metadata: Metadata = {
-  title: "DocSign - Online Document Signing",
+  title: "Seuk - Online Document Signing",
   description: "Upload, sign, and share documents online with ease",
 }
 

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -3,8 +3,8 @@ import { Suspense } from "react"
 import RegisterPage from "./RegisterPage"
 
 export const metadata: Metadata = {
-  title: "DocSign - Register",
-  description: "Create a new DocSign account",
+  title: "Seuk - Register",
+  description: "Create a new Seuk account",
 }
 
 export default function Register() {

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -395,7 +395,7 @@ const translations: Record<Language, Record<string, string>> = {
   },
   en: {
     // Header
-    "app.title": "슥슥",
+    "app.title": "Seuk",
     "app.description": "Upload, sign, and share documents online with ease",
 
     // Document Upload
@@ -645,13 +645,13 @@ const translations: Record<Language, Record<string, string>> = {
     "home.getStarted": "Get Started",
     "home.hero.title": "Document Signing Made Simple",
     "home.hero.description":
-      "Experience paperless document workflows with 슥슥. Sign and share documents securely from anywhere.",
+      "Experience paperless document workflows with Seuk. Sign and share documents securely from anywhere.",
     "home.hero.cta": "Start Now",
     "home.hero.learnMore": "Learn More",
     "home.hero.trustedBy": "Trusted by thousands of users",
     "home.featuresTitle": "Powerful Features",
     "home.featuresDescription":
-      "슥슥 offers a range of features to streamline your document signing process.",
+      "Seuk offers a range of features to streamline your document signing process.",
     "home.features.easy.title": "Easy to Use",
     "home.features.easy.description":
       "Intuitive interface that anyone can use without training.",
@@ -663,17 +663,17 @@ const translations: Record<Language, Record<string, string>> = {
       "Upload and sign documents in seconds, not minutes.",
     "home.testimonialsTitle": "Customer Testimonials",
     "home.testimonialsDescription":
-      "See what our customers are saying about 슥슥.",
+      "See what our customers are saying about Seuk.",
     "home.testimonials.quote1":
-      "슥슥 completely transformed our contract process. What used to take days now takes minutes.",
+      "Seuk completely transformed our contract process. What used to take days now takes minutes.",
     "home.testimonials.author1": "John Smith",
     "home.testimonials.role1": "Startup CEO",
     "home.testimonials.quote2":
-      "I was looking for an easy-to-use and secure signing solution, and 슥슥 was perfect. My clients love how easy it is to use.",
+      "I was looking for an easy-to-use and secure signing solution, and Seuk was perfect. My clients love how easy it is to use.",
     "home.testimonials.author2": "Sarah Johnson",
     "home.testimonials.role2": "Freelance Designer",
     "home.testimonials.quote3":
-      "Document signing was a major pain point in our remote work environment, but 슥슥 solved that. Highly recommended!",
+      "Document signing was a major pain point in our remote work environment, but Seuk solved that. Highly recommended!",
     "home.testimonials.author3": "Michael Chen",
     "home.testimonials.role3": "HR Manager",
     "home.pricingTitle": "Simple Pricing",
@@ -704,7 +704,7 @@ const translations: Record<Language, Record<string, string>> = {
     "pricing.perMonth": "/month",
     "home.cta.title": "Get Started Today",
     "home.cta.description":
-      "Streamline your document signing process and save time and money with 슥슥.",
+      "Streamline your document signing process and save time and money with Seuk.",
     "home.cta.button": "Get Started",
     "home.footer.rights": "All rights reserved.",
 
@@ -727,7 +727,7 @@ const translations: Record<Language, Record<string, string>> = {
     "login.backToHome": "Back to home",
     "login.welcomeBack": "Welcome Back",
     "login.welcomeMessage":
-      "Sign in to 슥슥 to start signing and managing your documents. We provide a secure and fast signing experience.",
+      "Sign in to Seuk to start signing and managing your documents. We provide a secure and fast signing experience.",
     "login.kakaoTalk": "Kakao",
 
     // Register Page
@@ -743,9 +743,9 @@ const translations: Record<Language, Record<string, string>> = {
     "register.alreadyHaveAccount": "Already have an account?",
     "register.login": "Log in",
     "register.backToHome": "Back to home",
-    "register.joinUs": "Join 슥슥 Today",
+    "register.joinUs": "Join Seuk Today",
     "register.joinMessage":
-      "Sign up for 슥슥 to start signing and managing your documents. We provide a simple and secure signing experience.",
+      "Sign up for Seuk to start signing and managing your documents. We provide a simple and secure signing experience.",
     "register.kakaoTalk": "Kakao",
     
     // Auth Errors - Server Actions

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -29,7 +29,7 @@ const LanguageContext = createContext<LanguageContextType>({
 const translations: Record<Language, Record<string, string>> = {
   ko: {
     // Header
-    "app.title": "DocSign",
+    "app.title": "슥슥",
     "app.description": "문서를 쉽게 업로드하고, 서명하고, 공유하세요",
 
     // Document Upload
@@ -278,13 +278,13 @@ const translations: Record<Language, Record<string, string>> = {
     "home.getStarted": "시작하기",
     "home.hero.title": "문서 서명, 더 쉽고 빠르게",
     "home.hero.description":
-      "DocSign으로 종이 없는 문서 워크플로우를 경험하세요. 어디서나 안전하게 문서에 서명하고 공유할 수 있습니다.",
+      "슥슥으로 종이 없는 문서 워크플로우를 경험하세요. 어디서나 안전하게 문서에 서명하고 공유할 수 있습니다.",
     "home.hero.cta": "지금 시작하기",
     "home.hero.learnMore": "더 알아보기",
     "home.hero.trustedBy": "수천 명의 사용자가 신뢰하는 서비스",
     "home.featuresTitle": "강력한 기능",
     "home.featuresDescription":
-      "DocSign은 문서 서명 프로세스를 간소화하는 다양한 기능을 제공합니다.",
+      "슥슥은 문서 서명 프로세스를 간소화하는 다양한 기능을 제공합니다.",
     "home.features.easy.title": "간편한 사용",
     "home.features.easy.description":
       "직관적인 인터페이스로 누구나 쉽게 사용할 수 있습니다.",
@@ -296,17 +296,17 @@ const translations: Record<Language, Record<string, string>> = {
       "몇 초 만에 문서를 업로드하고 서명할 수 있습니다.",
     "home.testimonialsTitle": "고객 후기",
     "home.testimonialsDescription":
-      "DocSign을 사용하는 고객들의 생생한 후기를 확인해보세요.",
+      "슥슥을 사용하는 고객들의 생생한 후기를 확인해보세요.",
     "home.testimonials.quote1":
-      "DocSign은 우리 회사의 계약 프로세스를 완전히 바꿔놓았습니다. 이전에는 서류 작업에 며칠이 걸렸지만, 이제는 몇 분 만에 완료됩니다.",
+      "슥슥은 우리 회사의 계약 프로세스를 완전히 바꿔놓았습니다. 이전에는 서류 작업에 며칠이 걸렸지만, 이제는 몇 분 만에 완료됩니다.",
     "home.testimonials.author1": "김민수",
     "home.testimonials.role1": "스타트업 CEO",
     "home.testimonials.quote2":
-      "사용하기 쉽고 안전한 서명 솔루션을 찾고 있었는데, DocSign이 완벽했습니다. 고객들도 사용하기 쉽다고 좋아합니다.",
+      "사용하기 쉽고 안전한 서명 솔루션을 찾고 있었는데, 슥슥이 완벽했습니다. 고객들도 사용하기 쉽다고 좋아합니다.",
     "home.testimonials.author2": "이지현",
     "home.testimonials.role2": "프리랜서 디자이너",
     "home.testimonials.quote3":
-      "원격 근무 환경에서 문서 서명이 큰 문제였는데, DocSign 덕분에 이제는 걱정이 없습니다. 강력히 추천합니다!",
+      "원격 근무 환경에서 문서 서명이 큰 문제였는데, 슥슥 덕분에 이제는 걱정이 없습니다. 강력히 추천합니다!",
     "home.testimonials.author3": "박준호",
     "home.testimonials.role3": "인사 관리자",
     "home.pricingTitle": "합리적인 가격",
@@ -336,7 +336,7 @@ const translations: Record<Language, Record<string, string>> = {
     "pricing.perMonth": "월",
     "home.cta.title": "지금 바로 시작하세요",
     "home.cta.description":
-      "DocSign으로 문서 서명 프로세스를 간소화하고 시간과 비용을 절약하세요.",
+      "슥슥으로 문서 서명 프로세스를 간소화하고 시간과 비용을 절약하세요.",
     "home.cta.button": "지금 시작하기",
     "home.footer.rights": "모든 권리 보유.",
 
@@ -359,7 +359,7 @@ const translations: Record<Language, Record<string, string>> = {
     "login.backToHome": "홈으로",
     "login.welcomeBack": "다시 만나서 반갑습니다",
     "login.welcomeMessage":
-      "DocSign에 로그인하여 문서 서명 및 관리를 시작하세요. 안전하고 빠른 서명 경험을 제공합니다.",
+      "슥슥에 로그인하여 문서 서명 및 관리를 시작하세요. 안전하고 빠른 서명 경험을 제공합니다.",
     "login.kakaoTalk": "카카오",
 
     // Register Page
@@ -375,9 +375,9 @@ const translations: Record<Language, Record<string, string>> = {
     "register.alreadyHaveAccount": "이미 계정이 있으신가요?",
     "register.login": "로그인",
     "register.backToHome": "홈으로",
-    "register.joinUs": "DocSign에 가입하세요",
+    "register.joinUs": "슥슥에 가입하세요",
     "register.joinMessage":
-      "DocSign에 가입하여 문서 서명 및 관리를 시작하세요. 간편하고 안전한 서명 경험을 제공합니다.",
+      "슥슥에 가입하여 문서 서명 및 관리를 시작하세요. 간편하고 안전한 서명 경험을 제공합니다.",
     "register.kakaoTalk": "카카오",
     
     // Auth Errors - Server Actions
@@ -395,7 +395,7 @@ const translations: Record<Language, Record<string, string>> = {
   },
   en: {
     // Header
-    "app.title": "DocSign",
+    "app.title": "슥슥",
     "app.description": "Upload, sign, and share documents online with ease",
 
     // Document Upload
@@ -645,13 +645,13 @@ const translations: Record<Language, Record<string, string>> = {
     "home.getStarted": "Get Started",
     "home.hero.title": "Document Signing Made Simple",
     "home.hero.description":
-      "Experience paperless document workflows with DocSign. Sign and share documents securely from anywhere.",
+      "Experience paperless document workflows with 슥슥. Sign and share documents securely from anywhere.",
     "home.hero.cta": "Start Now",
     "home.hero.learnMore": "Learn More",
     "home.hero.trustedBy": "Trusted by thousands of users",
     "home.featuresTitle": "Powerful Features",
     "home.featuresDescription":
-      "DocSign offers a range of features to streamline your document signing process.",
+      "슥슥 offers a range of features to streamline your document signing process.",
     "home.features.easy.title": "Easy to Use",
     "home.features.easy.description":
       "Intuitive interface that anyone can use without training.",
@@ -663,17 +663,17 @@ const translations: Record<Language, Record<string, string>> = {
       "Upload and sign documents in seconds, not minutes.",
     "home.testimonialsTitle": "Customer Testimonials",
     "home.testimonialsDescription":
-      "See what our customers are saying about DocSign.",
+      "See what our customers are saying about 슥슥.",
     "home.testimonials.quote1":
-      "DocSign completely transformed our contract process. What used to take days now takes minutes.",
+      "슥슥 completely transformed our contract process. What used to take days now takes minutes.",
     "home.testimonials.author1": "John Smith",
     "home.testimonials.role1": "Startup CEO",
     "home.testimonials.quote2":
-      "I was looking for an easy-to-use and secure signing solution, and DocSign was perfect. My clients love how easy it is to use.",
+      "I was looking for an easy-to-use and secure signing solution, and 슥슥 was perfect. My clients love how easy it is to use.",
     "home.testimonials.author2": "Sarah Johnson",
     "home.testimonials.role2": "Freelance Designer",
     "home.testimonials.quote3":
-      "Document signing was a major pain point in our remote work environment, but DocSign solved that. Highly recommended!",
+      "Document signing was a major pain point in our remote work environment, but 슥슥 solved that. Highly recommended!",
     "home.testimonials.author3": "Michael Chen",
     "home.testimonials.role3": "HR Manager",
     "home.pricingTitle": "Simple Pricing",
@@ -704,7 +704,7 @@ const translations: Record<Language, Record<string, string>> = {
     "pricing.perMonth": "/month",
     "home.cta.title": "Get Started Today",
     "home.cta.description":
-      "Streamline your document signing process and save time and money with DocSign.",
+      "Streamline your document signing process and save time and money with 슥슥.",
     "home.cta.button": "Get Started",
     "home.footer.rights": "All rights reserved.",
 
@@ -727,7 +727,7 @@ const translations: Record<Language, Record<string, string>> = {
     "login.backToHome": "Back to home",
     "login.welcomeBack": "Welcome Back",
     "login.welcomeMessage":
-      "Sign in to DocSign to start signing and managing your documents. We provide a secure and fast signing experience.",
+      "Sign in to 슥슥 to start signing and managing your documents. We provide a secure and fast signing experience.",
     "login.kakaoTalk": "Kakao",
 
     // Register Page
@@ -743,9 +743,9 @@ const translations: Record<Language, Record<string, string>> = {
     "register.alreadyHaveAccount": "Already have an account?",
     "register.login": "Log in",
     "register.backToHome": "Back to home",
-    "register.joinUs": "Join DocSign Today",
+    "register.joinUs": "Join 슥슥 Today",
     "register.joinMessage":
-      "Sign up for DocSign to start signing and managing your documents. We provide a simple and secure signing experience.",
+      "Sign up for 슥슥 to start signing and managing your documents. We provide a simple and secure signing experience.",
     "register.kakaoTalk": "Kakao",
     
     // Auth Errors - Server Actions

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "my-v0-project",
+  "name": "seuk-document-signing",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- Implement language-responsive logo that changes based on selected language
- Korean language displays "슥슥" in logo text
- English language displays "Seuk" in logo text
- Logo automatically updates when user switches languages

## Changes Made
- 🔧 Fixed language context translations to properly differentiate logo text
- 🇰🇷 Korean `app.title`: "슥슥" (maintained Korean branding)
- 🇺🇸 English `app.title`: "Seuk" (English transliteration)
- ✅ Logo updates automatically via existing `t("app.title")` implementation

## Technical Implementation
- Uses existing translation system (`useLanguage` hook)
- Logo text is pulled from `app.title` translation key
- No additional components or logic needed - works with current language switcher
- Maintains consistency across all pages (header, footer, etc.)

## Test Plan
- ✅ Build completed successfully
- ✅ Korean language shows "슥슥" in logo
- ✅ English language shows "Seuk" in logo
- ✅ Language switching triggers logo update automatically
- ✅ All existing functionality preserved

## User Experience
Users can now see the logo in their preferred language:
- Korean users see familiar "슥슥" branding
- English users see "Seuk" for better readability
- Seamless switching between languages updates logo instantly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 모든 화면 및 메타데이터의 제품명이 "DocSign"에서 "Seuk" 또는 "슥슥"으로 변경되었습니다.
  * 푸터의 저작권 텍스트가 "DocSign"에서 "Seuk"으로 수정되었습니다.
  * 다국어(한국어/영어) 번역 내 제품명 및 관련 문구가 일괄 변경되었습니다.
  * 프로젝트 이름이 "my-v0-project"에서 "seuk-document-signing"으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->