### PR TITLE
fix: 대시보드 문서 상세화면 공유 버튼 기능 개선

### DIFF
--- a/app/dashboard/queries.ts
+++ b/app/dashboard/queries.ts
@@ -60,7 +60,10 @@ export async function getDocumentById(documentId: string) {
   
   const { data, error } = await supabase
     .from('documents')
-    .select('*')
+    .select(`
+      *,
+      signature_areas (*)
+    `)
     .eq('id', documentId)
     .single()
   

--- a/app/document/[id]/DocumentDetailView.tsx
+++ b/app/document/[id]/DocumentDetailView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -20,14 +20,25 @@ import {
 import { format } from 'date-fns';
 import { ko, enUS } from 'date-fns/locale';
 import { useLanguage } from '@/contexts/language-context';
-import { deleteDocument } from '@/app/actions/document';
+import { deleteDocument, getDocumentSignedUrl, createDocumentShare } from '@/app/actions/document';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
 import type { User } from '@supabase/supabase-js';
 import type { LucideIcon } from 'lucide-react';
 
-// Simplified types based on your existing structure
+// Document types with signature areas
+interface SignatureArea {
+  id: string;
+  document_id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  order_index: number;
+  required: boolean;
+}
+
 interface DocumentDetailViewProps {
   document: {
     id: string;
@@ -38,6 +49,7 @@ interface DocumentDetailViewProps {
     file_path: string;
     file_name: string;
     user_id: string;
+    signature_areas?: SignatureArea[];
   };
   user: User;
 }
@@ -77,19 +89,66 @@ export function DocumentDetailView({ document, user }: DocumentDetailViewProps) 
   const { t, language } = useLanguage();
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
+  const [documentUrl, setDocumentUrl] = useState<string | null>(null);
+  const [isGeneratingShare, setIsGeneratingShare] = useState(false);
 
   const locale = language === 'ko' ? ko : enUS;
 
   const config = statusConfig[document.status];
   const StatusIcon = config.icon;
 
+  // Check if document has signature areas
+  const hasSignatureAreas = document.signature_areas && document.signature_areas.length > 0;
+  const canShare = document.status === 'draft' && hasSignatureAreas;
+
+  // Load document image
+  useEffect(() => {
+    async function loadDocumentImage() {
+      try {
+        const result = await getDocumentSignedUrl(document.id);
+        if (result.success && result.data) {
+          setDocumentUrl(result.data);
+        }
+      } catch (error) {
+        console.error('Error loading document image:', error);
+      }
+    }
+    
+    loadDocumentImage();
+  }, [document.id]);
+
   const handleEdit = () => {
     router.push(`/dashboard?mode=edit&documentId=${document.id}`);
   };
 
-  const handleShare = () => {
-    // TODO: Implement share functionality
-    console.log('Share document:', document.id);
+  const handleShare = async () => {
+    if (!canShare) {
+      toast.error(t('document.shareNotAvailable'));
+      return;
+    }
+
+    try {
+      setIsGeneratingShare(true);
+      const result = await createDocumentShare(document.id);
+      
+      if (result.success && result.data) {
+        const shareUrl = `${window.location.origin}/sign/${result.data}`;
+        
+        // Copy to clipboard
+        await navigator.clipboard.writeText(shareUrl);
+        toast.success(t('document.shareUrlCopied'));
+        
+        // Refresh to show updated status
+        router.refresh();
+      } else {
+        toast.error(result.error || t('document.shareError'));
+      }
+    } catch (error) {
+      console.error('Share error:', error);
+      toast.error(t('document.shareError'));
+    } finally {
+      setIsGeneratingShare(false);
+    }
   };
 
   const handleDelete = async () => {
@@ -221,11 +280,39 @@ export function DocumentDetailView({ document, user }: DocumentDetailViewProps) 
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="text-center py-8">
-            <p className="text-muted-foreground">
-              {t('document.previewPlaceholder')}
-            </p>
-          </div>
+          {documentUrl ? (
+            <div className="relative max-w-full mx-auto">
+              <img
+                src={documentUrl}
+                alt={document.title}
+                className="w-full h-auto max-h-96 object-contain border rounded-lg"
+                onError={() => setDocumentUrl(null)}
+              />
+              {/* Render signature areas */}
+              {hasSignatureAreas && document.signature_areas?.map((area, index) => (
+                <div
+                  key={area.id}
+                  className="absolute border-2 border-red-500 border-dashed bg-red-100/20"
+                  style={{
+                    left: `${area.x}%`,
+                    top: `${area.y}%`,
+                    width: `${area.width}%`,
+                    height: `${area.height}%`,
+                  }}
+                >
+                  <div className="absolute -top-6 left-0 bg-red-500 text-white text-xs px-2 py-1 rounded">
+                    {t('document.signatureArea')} {index + 1}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-center py-8">
+              <p className="text-muted-foreground">
+                {t('document.previewPlaceholder')}
+              </p>
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -237,9 +324,14 @@ export function DocumentDetailView({ document, user }: DocumentDetailViewProps) 
             {t('dashboard.actions.edit')}
           </Button>
           
-          <Button variant="outline" onClick={handleShare} className="gap-2">
+          <Button 
+            variant="outline" 
+            onClick={handleShare} 
+            className="gap-2"
+            disabled={!canShare || isGeneratingShare}
+          >
             <Share2 className="w-4 h-4" />
-            {t('dashboard.actions.share')}
+            {isGeneratingShare ? t('document.generatingShareUrl') : t('dashboard.actions.share')}
           </Button>
           
           <Button variant="outline" onClick={handleDownload} className="gap-2">

--- a/contexts/language-context.tsx
+++ b/contexts/language-context.tsx
@@ -246,6 +246,11 @@ const translations: Record<Language, Record<string, string>> = {
     "document.preview": "문서 미리보기",
     "document.previewPlaceholder": "문서 미리보기가 여기에 표시됩니다.",
     "document.download": "다운로드",
+    "document.shareNotAvailable": "서명영역이 설정되지 않은 초안은 공유할 수 없습니다",
+    "document.shareUrlCopied": "공유 링크가 클립보드에 복사되었습니다",
+    "document.shareError": "공유 링크 생성에 실패했습니다",
+    "document.generatingShareUrl": "링크 생성 중...",
+    "document.signatureArea": "서명 영역",
     "dashboard.status.submitted": "제출됨",
 
     // Signer Onboarding
@@ -662,6 +667,11 @@ const translations: Record<Language, Record<string, string>> = {
     "document.preview": "Document Preview",
     "document.previewPlaceholder": "Document preview will be displayed here.",
     "document.download": "Download",
+    "document.shareNotAvailable": "Drafts without signature areas cannot be shared",
+    "document.shareUrlCopied": "Share link copied to clipboard",
+    "document.shareError": "Failed to generate share link",
+    "document.generatingShareUrl": "Generating link...",
+    "document.signatureArea": "Signature Area",
     "dashboard.status.submitted": "Submitted",
 
     // Homepage


### PR DESCRIPTION
## Summary
- 대시보드 문서 상세화면에서 공유 버튼이 올바른 조건에서만 활성화되도록 수정
- 문서 미리보기에 실제 문서 이미지와 서명영역을 시각적으로 표시
- 공유 버튼 클릭시 기존 공유링크 생성 기능과 연결

## Changes
- **공유 버튼 조건**: 초안 상태 + 서명영역 설정 완료일 때만 활성화
- **문서 미리보기**: 실제 문서 이미지 표시 및 서명영역 오버레이
- **공유 기능**: 기존 `createDocumentShare` 함수 연결
- **사용자 경험**: 공유 URL 클립보드 자동 복사 및 성공/실패 피드백
- **다국어**: 관련 번역 키 추가 (한국어/영어)

## Technical Details
- `app/dashboard/queries.ts`: 서명영역 정보를 포함한 문서 조회
- `app/document/[id]/DocumentDetailView.tsx`: 공유 버튼 로직 및 미리보기 구현
- `contexts/language-context.tsx`: 관련 번역 키 추가

## Test plan
- [x] 초안 문서에서 서명영역이 없을 때 공유 버튼 비활성화 확인
- [x] 초안 문서에서 서명영역이 있을 때 공유 버튼 활성화 확인
- [x] 진행중/완료 상태 문서에서 공유 버튼 비활성화 확인
- [x] 문서 미리보기에 이미지와 서명영역 표시 확인
- [x] 공유 버튼 클릭시 링크 생성 및 클립보드 복사 확인

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새로운 기능
  - 문서 상세 화면에서 서명된 URL을 통해 실제 문서 이미지를 표시하고, 로드 실패 시 기존 플레이스홀더를 유지합니다.
  - 서명 영역이 있는 경우 이미지 위에 위치/크기 비율을 활용한 강조 오버레이와 라벨을 표시합니다.
  - 초안 상태이면서 서명 영역이 있을 때만 공유 가능하며, 공유 URL 생성·클립보드 복사, 진행 상태 표시, 버튼 비활성화, 성공/오류 알림을 제공합니다.
- 로컬라이제이션
  - 공유 관련 안내 및 서명 영역 라벨 번역 키(ko/en) 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->